### PR TITLE
German keyboard fix (AltGr combinations)

### DIFF
--- a/converter/js/converter.js
+++ b/converter/js/converter.js
@@ -227,6 +227,7 @@ class malduinoScriptConverter{
 					$.ajax({url: url+"/locales/"+lang+".lang", success: function(result){
 						langFile = result;
 						if(lang == "es_ES") keyboardCPP = "#define ADD_ALTGR\r\n";
+						if(lang == "de_DE") keyboardCPP = "#define ADD_ALTGR\r\n";
 						keyboardCPP += keyboardCPPbegin + langCopyrightNotice + langFile + keyboardCPPend;
 						loaded++;
 						

--- a/converter/src/Keyboard_end.cpp
+++ b/converter/src/Keyboard_end.cpp
@@ -25,8 +25,6 @@ size_t Keyboard_::press(uint8_t k)
 		if (!_altFine) initAltGr();
 		if (_altGrMap[oldKey]){
 		  _keyReport.modifiers |= 0x40;
-		} else {
-		  _keyReport.modifiers = 0;
 		}
 		#endif
 		
@@ -69,10 +67,19 @@ size_t Keyboard_::release(uint8_t k)
 		_keyReport.modifiers &= ~(1<<(k-128));
 		k = 0;
 	} else {				// it's a printing key
+    int oldKey = k;
 		k = pgm_read_byte(_asciimap + k);
 		if (!k) {
 			return 0;
 		}
+		
+    #ifdef ADD_ALTGR
+    if (!_altFine) initAltGr();
+    if (_altGrMap[oldKey]){
+      _keyReport.modifiers &= ~(0x40);
+    }
+    #endif
+   
 		if (k & 0x80) {							// it's a capital letter or other character reached with shift
 			_keyReport.modifiers &= ~(0x02);	// the left shift modifier
 			k &= 0x7F;


### PR DESCRIPTION
I will make it short:

`STRING \ { [ ] }`
was returning
`ß 7 8 9 0`

Now it is returning:
`\ { [ ] }`

And the other `AltGr` combinations are fixed too.

A more complex string:

Original String 
`!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~`

Unmodified Firmware
`!"#$%&ß'()*+,-./0123456789:;<=>?qABCDEFGHIJKLMNOPQRSTUVWXYZ8ßß9^_abcdefghijklmnopqrstuvwxyz7<0+`

With this fix applied:
`!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_abcdefghijklmnopqrstuvwxyz{|}~`
